### PR TITLE
feat: Implement Phase 2 variant application engine

### DIFF
--- a/hgvs2seq/apply/batch.py
+++ b/hgvs2seq/apply/batch.py
@@ -1,0 +1,30 @@
+from typing import List, TYPE_CHECKING
+from ..parse import VariantNorm
+from .single import apply_single_variant
+
+def apply_batch(ref_seq: str, variants: List[VariantNorm]) -> str:
+    """
+    Applies a batch of normalized variants to a reference cDNA sequence.
+
+    To prevent issues with coordinates shifting after an indel, variants are
+    applied in reverse order of their starting position.
+
+    Args:
+        ref_seq: The reference cDNA sequence.
+        variants: A list of VariantNorm objects to apply.
+
+    Returns:
+        The final modified cDNA sequence after all variants have been applied.
+    """
+    # Sort variants by start position in descending order.
+    # This is crucial to ensure that applying one variant doesn't invalidate the
+    # coordinates of subsequent variants. For example, a deletion at the start
+    # of the sequence would shift all other coordinates. By working from the
+    # end of the sequence to the beginning, we avoid this problem.
+    sorted_variants = sorted(variants, key=lambda v: v.c_start, reverse=True)
+
+    edited_seq = ref_seq
+    for variant in sorted_variants:
+        edited_seq = apply_single_variant(edited_seq, variant)
+
+    return edited_seq

--- a/hgvs2seq/apply/single.py
+++ b/hgvs2seq/apply/single.py
@@ -1,0 +1,83 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..parse import VariantNorm
+
+def apply_single_variant(ref_seq: str, variant: "VariantNorm") -> str:
+    """
+    Applies a single normalized variant to a reference cDNA sequence.
+
+    Args:
+        ref_seq: The reference cDNA sequence.
+        variant: A VariantNorm object representing the change.
+
+    Returns:
+        The modified cDNA sequence.
+
+    Raises:
+        ValueError: If the variant type is unknown or if the reference sequence
+                    is inconsistent with the variant's position.
+    """
+    # HGVS coordinates are 1-based, Python strings are 0-based.
+    # start_idx is inclusive, end_idx is exclusive for slicing.
+    start_idx = variant.c_start - 1
+    end_idx = variant.c_end
+
+    # Basic bounds checking
+    if not (0 <= start_idx <= end_idx <= len(ref_seq)):
+        raise ValueError(
+            f"Variant {variant.hgvs_c} coordinates ({variant.c_start}, {variant.c_end}) "
+            f"are out of bounds for sequence of length {len(ref_seq)}."
+        )
+
+    # Dispatch based on variant kind
+    kind = variant.kind
+    alt = variant.alt
+
+    if kind == "sub":
+        if alt is None:
+            raise ValueError(f"Substitution variant {variant.hgvs_c} is missing 'alt' sequence.")
+        # Substitution of a single base
+        return ref_seq[:start_idx] + alt + ref_seq[end_idx:]
+
+    elif kind == "del":
+        # Deletion of the sequence between start and end
+        return ref_seq[:start_idx] + ref_seq[end_idx:]
+
+    elif kind == "ins":
+        if alt is None:
+            raise ValueError(f"Insertion variant {variant.hgvs_c} is missing 'alt' sequence.")
+        # Insertion happens between two bases. HGVS c.1_2insA means insert after base 1.
+        # c_start is the base 5' to the insertion site, so we insert at its 0-based index.
+        # In this case, c_start=1, so index is 1.
+        # Let's re-verify: hgvs-python for c.1_2insA gives start=1, end=2.
+        # The insertion point is between them. In 0-based, that's after index 0, at index 1.
+        # So we insert at `start_idx + 1`.
+        # No, c.1_2insA means between base 1 and 2. So after index 0, and before index 1.
+        # The correct insertion point is `start_idx + 1`, but `hgvs-python` might give c_start as the insertion point.
+        # Let's assume c_start is the position *before* the insertion.
+        # `c.123_124insT` means insertion is at index 123. c_start=123.
+        # So, the insertion point is `start_idx`.
+        # Let's stick to the simplest interpretation: for c.1_2insA, c_start=1, c_end=2.
+        # Insertion point is after c_start. So after index 0. At index 1.
+        # `ref_seq[:1] + alt + ref_seq[1:]`. This seems right.
+        # The insertion point is `c_end - 1`
+        insertion_idx = variant.c_end - 1
+        return ref_seq[:insertion_idx] + alt + ref_seq[insertion_idx:]
+
+
+    elif kind in ("delins", "mnv"):
+        if alt is None:
+            raise ValueError(f"Variant {variant.hgvs_c} is missing 'alt' sequence.")
+        # Deletion of the specified range, followed by an insertion at the start of that range
+        return ref_seq[:start_idx] + alt + ref_seq[end_idx:]
+
+    elif kind == "dup":
+        # Duplication of the sequence in the given range
+        duplicated_seq = ref_seq[start_idx:end_idx]
+        # The duplication is inserted immediately after the original sequence
+        return ref_seq[:end_idx] + duplicated_seq + ref_seq[end_idx:]
+
+    else:
+        # Currently, 'inv' (inversion) is not supported.
+        raise ValueError(f"Unsupported variant kind: '{kind}'")

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,0 +1,107 @@
+import pytest
+from hgvs2seq.parse import VariantNorm
+from hgvs2seq.apply.single import apply_single_variant
+from hgvs2seq.apply.batch import apply_batch
+
+# A sample reference sequence for testing: ATG GCC TCA TGA TAG CAT CAT CAT CAT C
+REF_SEQ = "ATGGCCTCATGATAGCATCATCATCATC"
+
+@pytest.fixture
+def ref_seq() -> str:
+    """Provides the reference sequence for tests."""
+    return REF_SEQ
+
+# =============================================================================
+# Tests for apply_single_variant
+# =============================================================================
+
+def test_apply_sub(ref_seq: str):
+    """Test a single nucleotide substitution."""
+    # c.4G>T changes the sequence from ATGGCCT... to ATGTCCT...
+    variant = VariantNorm(hgvs_c="c.4G>T", kind="sub", c_start=4, c_end=4, alt="T", meta={})
+    expected_seq = "ATGTCCTCATGATAGCATCATCATCATC"
+    result_seq = apply_single_variant(ref_seq, variant)
+    assert result_seq == expected_seq
+
+def test_apply_del(ref_seq: str):
+    """Test a deletion of a few bases."""
+    # c.4_6del removes GCC from ATG-GCC-TCA... to become ATG-TCA...
+    variant = VariantNorm(hgvs_c="c.4_6del", kind="del", c_start=4, c_end=6, alt=None, meta={})
+    expected_seq = "ATGTCATGATAGCATCATCATCATC"
+    result_seq = apply_single_variant(ref_seq, variant)
+    assert result_seq == expected_seq
+
+def test_apply_ins(ref_seq: str):
+    """Test a simple insertion."""
+    # c.6_7insA inserts 'A' between base 6 (C) and 7 (T)
+    # ATG-GCC-TCA... becomes ATG-GCC-A-TCA...
+    variant = VariantNorm(hgvs_c="c.6_7insA", kind="ins", c_start=6, c_end=7, alt="A", meta={})
+    expected_seq = "ATGGCCATCATGATAGCATCATCATCATC"
+    result_seq = apply_single_variant(ref_seq, variant)
+    assert result_seq == expected_seq
+
+def test_apply_delins(ref_seq: str):
+    """Test a deletion followed by an insertion."""
+    # c.4_6delinsTT removes GCC and inserts TT
+    # ATG-GCC-TCA... becomes ATG-TT-TCA...
+    variant = VariantNorm(hgvs_c="c.4_6delinsTT", kind="delins", c_start=4, c_end=6, alt="TT", meta={})
+    expected_seq = "ATGTTTCATGATAGCATCATCATCATC"
+    result_seq = apply_single_variant(ref_seq, variant)
+    assert result_seq == expected_seq
+
+def test_apply_mnv(ref_seq: str):
+    """Test a multi-nucleotide variant (a delins of the same length)."""
+    # c.4_6delinsTTA removes GCC and inserts TTA
+    # ATG-GCC-TCA... becomes ATG-TTA-TCA...
+    variant = VariantNorm(hgvs_c="c.4_6delinsTTA", kind="mnv", c_start=4, c_end=6, alt="TTA", meta={})
+    expected_seq = "ATGTTATCATGATAGCATCATCATCATC"
+    result_seq = apply_single_variant(ref_seq, variant)
+    assert result_seq == expected_seq
+
+def test_apply_dup(ref_seq: str):
+    """Test a duplication."""
+    # c.4_6dup duplicates GCC
+    # ATG-GCC-TCA... becomes ATG-GCC-GCC-TCA...
+    variant = VariantNorm(hgvs_c="c.4_6dup", kind="dup", c_start=4, c_end=6, alt=None, meta={})
+    expected_seq = "ATGGCCGCCTCATGATAGCATCATCATCATC"
+    result_seq = apply_single_variant(ref_seq, variant)
+    assert result_seq == expected_seq
+
+# =============================================================================
+# Tests for apply_batch
+# =============================================================================
+
+def test_apply_batch_non_overlapping(ref_seq: str):
+    """Test applying a batch of non-overlapping variants."""
+    variants = [
+        VariantNorm(hgvs_c="c.4_6del", kind="del", c_start=4, c_end=6, alt=None, meta={}),      # Deletes GCC
+        VariantNorm(hgvs_c="c.10_11insA", kind="ins", c_start=10, c_end=11, alt="A", meta={}) # Inserts A between T and G
+    ]
+    # Starting sequence: ATGGCCTCATGATAGCATCATCATCATC
+    # 1. Apply c.10_11insA: ATGGCCTCAT-A-GATAGCAT...
+    # 2. Apply c.4_6del on the new sequence: ATG-TCAT-A-GATAGCAT...
+    expected_seq = "ATGTCATAGATAGCATCATCATCATC"
+    result_seq = apply_batch(ref_seq, variants)
+    assert result_seq == expected_seq
+
+def test_apply_batch_order_independence(ref_seq: str):
+    """Test that the order of variants in the input list doesn't matter."""
+    variants_shuffled = [
+        VariantNorm(hgvs_c="c.10_11insA", kind="ins", c_start=10, c_end=11, alt="A", meta={}),
+        VariantNorm(hgvs_c="c.4_6del", kind="del", c_start=4, c_end=6, alt=None, meta={})
+    ]
+    expected_seq = "ATGTCATAGATAGCATCATCATCATC"
+    result_seq = apply_batch(ref_seq, variants_shuffled)
+    assert result_seq == expected_seq
+
+def test_out_of_bounds_error(ref_seq: str):
+    """Test that a variant outside the sequence bounds raises an error."""
+    variant = VariantNorm(hgvs_c="c.100G>A", kind="sub", c_start=100, c_end=100, alt="A", meta={})
+    with pytest.raises(ValueError, match="out of bounds"):
+        apply_single_variant(ref_seq, variant)
+
+def test_unsupported_kind_error(ref_seq: str):
+    """Test that an unsupported variant kind raises an error."""
+    variant = VariantNorm(hgvs_c="c.1_2inv", kind="inv", c_start=1, c_end=2, alt=None, meta={})
+    with pytest.raises(ValueError, match="Unsupported variant kind"):
+        apply_single_variant(ref_seq, variant)


### PR DESCRIPTION
This commit introduces the core logic for applying genetic variants to a reference cDNA sequence, as outlined in Phase 2 of the project plan.

Key changes include:
- `hgvs2seq/apply/single.py`: A new module containing `apply_single_variant`, a function that applies a single normalized HGVS variant to a sequence. It supports substitutions, deletions, insertions, delins, and duplications.
- `hgvs2seq/apply/batch.py`: A new module with the `apply_batch` function, which processes a list of variants. It sorts them in reverse order of position to correctly handle coordinate changes from indels.
- `tests/test_apply.py`: A new test file with comprehensive unit tests for both single and batch application logic, ensuring correctness and handling of edge cases.

The implementation is robust and fully tested, completing the requirements for Phase 2.