### PR TITLE
Feat: Add CLI and Configurable Splicing/NMD Parameters

### DIFF
--- a/hgvs2seq/__init__.py
+++ b/hgvs2seq/__init__.py
@@ -20,6 +20,7 @@ def apply_variants(
     annotate_splicing: bool = False,
     annotate_nmd: bool = False,
     spliceai_params: Optional[Dict[str, Any]] = None,
+    nmd_params: Optional[Dict[str, Any]] = None,
 ) -> SequenceBundle:
     """
     The main entry point for applying a list of HGVS variants to a transcript.
@@ -125,7 +126,9 @@ def apply_variants(
                 hap_ann["splicing"] = hap_splicing_ann
 
             if annotate_nmd:
-                hap_ann["nmd"] = check_nmd(edited_cdna, protein_ref, cfg)
+                hap_ann["nmd"] = check_nmd(
+                    edited_cdna, protein_ref, cfg, **(nmd_params or {})
+                )
 
         protein_edited_list.append(prot_edited)
         annotations["haplotypes"].append(hap_ann)

--- a/hgvs2seq/cli.py
+++ b/hgvs2seq/cli.py
@@ -1,0 +1,205 @@
+import json
+import logging
+from pathlib import Path
+from typing import TextIO
+
+import click
+
+from hgvs2seq import apply_variants, load_config, VariantIn
+from hgvs2seq.config import TranscriptConfig
+
+# Set up basic logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+logger = logging.getLogger(__name__)
+
+def parse_variants_file(file: TextIO) -> list[VariantIn]:
+    """Parses a file with one HGVS string per line."""
+    variants = []
+    for line in file:
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Rudimentary phase parsing from comments, e.g., #phase=1
+        phase_group = None
+        if "#" in line:
+            comment = line.split("#", 1)[1]
+            if "phase=" in comment:
+                try:
+                    phase_group = int(comment.split("phase=")[1].strip())
+                except (ValueError, IndexError):
+                    logger.warning(f"Could not parse phase from comment: '{comment}'")
+            line = line.split("#", 1)[0].strip()
+
+        variants.append(VariantIn(hgvs=line, phase_group=phase_group))
+    return variants
+
+@click.command()
+@click.option(
+    "--transcript",
+    required=True,
+    help="Transcript ID (e.g., NM_000551.3). A corresponding config JSON file is expected.",
+)
+@click.option(
+    "--assembly",
+    required=True,
+    help="Reference assembly (e.g., GRCh38).",
+)
+@click.option(
+    "--variants",
+    "variants_file",
+    type=click.File("r"),
+    required=True,
+    help="Path to a file containing HGVS strings, one per line.",
+)
+@click.option(
+    "--out",
+    "out_json_file",
+    type=click.File("w"),
+    help="Path to write the output JSON SequenceBundle.",
+)
+@click.option(
+    "--fasta",
+    "out_fasta_file",
+    type=click.File("w"),
+    help="Path to write the output FASTA sequences (cDNA and protein).",
+)
+@click.option(
+    "--policy",
+    type=click.Choice(["order_by_pos", "reject_overlaps"], case_sensitive=False),
+    default="order_by_pos",
+    show_default=True,
+    help="Policy for handling overlapping variants.",
+)
+@click.option(
+    "--emit",
+    default="cdna,protein",
+    show_default=True,
+    help="Comma-separated list of sequences to output (e.g., 'cdna,protein').",
+)
+@click.option(
+    "--annotate-splicing/--no-annotate-splicing",
+    default=False,
+    show_default=True,
+    help="Enable SpliceAI annotation.",
+)
+@click.option(
+    "--reference-path",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to the reference genome FASTA file (required for SpliceAI).",
+)
+@click.option(
+    "--spliceai-distance",
+    type=int,
+    default=500,
+    show_default=True,
+    help="SpliceAI: maximum distance between variant and splice site.",
+)
+@click.option(
+    "--annotate-nmd/--no-annotate-nmd",
+    default=False,
+    show_default=True,
+    help="Enable NMD prediction.",
+)
+@click.option(
+    "--nmd-threshold",
+    type=int,
+    default=50,
+    show_default=True,
+    help="NMD: distance from PTC to last exon-exon junction to trigger NMD.",
+)
+def main(
+    transcript: str,
+    assembly: str,
+    variants_file: TextIO,
+    out_json_file: TextIO | None,
+    out_fasta_file: TextIO | None,
+    policy: str,
+    emit: str,
+    annotate_splicing: bool,
+    reference_path: str | None,
+    spliceai_distance: int,
+    annotate_nmd: bool,
+    nmd_threshold: int,
+):
+    """
+    Applies HGVS variants to a transcript and predicts the consequences.
+    """
+    logger.info(f"Processing transcript {transcript} on assembly {assembly}")
+
+    # --- Configuration and Input Parsing ---
+    try:
+        # Assuming load_config can find a file like `NM_000551.3.json` or fetch it.
+        config_path = f"{transcript}.json"
+        if not Path(config_path).exists():
+             logger.warning(f"Config file {config_path} not found. `load_config` will try to fetch from UTA.")
+        cfg = load_config(config_path)
+        # Override assembly if provided on CLI
+        cfg.assembly = assembly
+    except Exception as e:
+        logger.error(f"Failed to load transcript configuration for {transcript}: {e}")
+        raise click.Abort()
+
+    variants = parse_variants_file(variants_file)
+    logger.info(f"Loaded {len(variants)} variants from {variants_file.name}")
+
+    outputs_set = set(emit.split(','))
+
+    # --- Parameter Validation and Preparation ---
+    if annotate_splicing and not reference_path:
+        logger.error("--reference-path is required when --annotate-splicing is enabled.")
+        raise click.Abort()
+
+    spliceai_params = {
+        "reference_path": reference_path,
+        "distance": spliceai_distance,
+    }
+
+    nmd_params = {
+        "nmd_threshold": nmd_threshold,
+    }
+
+    # --- Core Logic ---
+    try:
+        bundle = apply_variants(
+            cfg=cfg,
+            variants=variants,
+            policy=policy,
+            outputs=outputs_set,
+            annotate_splicing=annotate_splicing,
+            annotate_nmd=annotate_nmd,
+            spliceai_params=spliceai_params,
+            nmd_params=nmd_params,
+        )
+    except Exception as e:
+        logger.error(f"An error occurred during variant application: {e}")
+        raise click.Abort()
+
+    # --- Output Generation ---
+    if out_json_file:
+        logger.info(f"Writing JSON output to {out_json_file.name}")
+        out_json_file.write(bundle.model_dump_json(indent=2))
+
+    if out_fasta_file:
+        logger.info(f"Writing FASTA output to {out_fasta_file.name}")
+        # Write reference sequences
+        if "cdna" in outputs_set:
+            out_fasta_file.write(f">cdna_ref|{cfg.transcript_id}\n")
+            out_fasta_file.write(bundle.cdna_ref + "\n")
+        if "protein" in outputs_set and bundle.protein_ref:
+            out_fasta_file.write(f">protein_ref|{cfg.transcript_id}\n")
+            out_fasta_file.write(bundle.protein_ref + "\n")
+
+        # Write edited sequences per haplotype
+        for i, (cdna_edited, prot_edited) in enumerate(zip(bundle.cdna_edited, bundle.protein_edited)):
+            hap_id = f"haplotype_{i+1}"
+            if "cdna" in outputs_set and cdna_edited:
+                out_fasta_file.write(f">cdna_edited|{cfg.transcript_id}|{hap_id}\n")
+                out_fasta_file.write(cdna_edited + "\n")
+            if "protein" in outputs_set and prot_edited:
+                out_fasta_file.write(f">protein_edited|{cfg.transcript_id}|{hap_id}\n")
+                out_fasta_file.write(prot_edited + "\n")
+
+    logger.info("Processing complete.")
+
+if __name__ == "__main__":
+    main()

--- a/hgvs2seq/consequence/nmd.py
+++ b/hgvs2seq/consequence/nmd.py
@@ -3,13 +3,15 @@ from typing import Dict, Any, Optional
 from ..config import TranscriptConfig
 from .cds import extract_cds, translate
 
-# The distance from a PTC to the final exon-exon junction that typically triggers NMD.
-NMD_THRESHOLD = 50
+# The default distance from a PTC to the final exon-exon junction that typically triggers NMD.
+NMD_THRESHOLD_DEFAULT = 50
 
 def check_nmd(
     edited_cdna: str,
     protein_ref: Optional[str],
     config: TranscriptConfig,
+    *,
+    nmd_threshold: int = NMD_THRESHOLD_DEFAULT,
 ) -> Dict[str, Any]:
     """
     Applies a standard set of rules to determine if a transcript with a
@@ -84,10 +86,10 @@ def check_nmd(
     # Main NMD rule: Check distance from PTC to the last junction.
     distance = last_junction_pos_c - ptc_cdna_pos_1based
 
-    if distance >= NMD_THRESHOLD:
+    if distance >= nmd_threshold:
         return {
             "result": "NMD_likely",
-            "reason": f"PTC is {distance} nt upstream of the final exon-exon junction (>= {NMD_THRESHOLD} nt).",
+            "reason": f"PTC is {distance} nt upstream of the final exon-exon junction (>= {nmd_threshold} nt).",
             "ptc_position": ptc_cdna_pos_1based,
             "last_junction_position": last_junction_pos_c,
             "distance": distance,
@@ -95,7 +97,7 @@ def check_nmd(
     else:
         return {
             "result": "NMD_escaped",
-            "reason": f"PTC is {distance} nt upstream of the final exon-exon junction (< {NMD_THRESHOLD} nt).",
+            "reason": f"PTC is {distance} nt upstream of the final exon-exon junction (< {nmd_threshold} nt).",
             "ptc_position": ptc_cdna_pos_1based,
             "last_junction_position": last_junction_pos_c,
             "distance": distance,

--- a/poetry.lock
+++ b/poetry.lock
@@ -226,6 +226,21 @@ files = [
 ]
 
 [[package]]
+name = "click"
+version = "8.3.0"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc"},
+    {file = "click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -498,7 +513,6 @@ configparser = ">=3.3.0"
 importlib_resources = "*"
 ipython = "*"
 parsley = "*"
-psycopg2 = "*"
 
 [package.extras]
 dev = ["black", "flake8", "ipython", "isort", "jupyter", "pre-commit (>=3.4,<4.0)", "pytest", "pytest-cov", "pytest-recording", "restview", "setuptools", "sphinx", "sphinx_rtd_theme", "sphinxcontrib-fulltoc (>=1.1)", "toml-sort", "tox", "vcrpy", "yapf"]
@@ -903,10 +917,10 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.21.2", markers = "python_version >= \"3.10\""},
-    {version = ">=1.23.3", markers = "python_version >= \"3.11\""},
     {version = ">=2.1.0", markers = "python_version >= \"3.13\""},
     {version = ">=1.26.0", markers = "python_version == \"3.12\""},
+    {version = ">=1.23.3", markers = "python_version == \"3.11\""},
+    {version = ">=1.21.2", markers = "python_version == \"3.10\""},
 ]
 
 [package.extras]
@@ -1338,9 +1352,9 @@ files = [
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
-    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
     {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
+    {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.22.4", markers = "python_version < \"3.11\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -2682,4 +2696,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "11ccc60e42791add3168f215621104914dbcfe0cb6a7a9e019070545de01231a"
+content-hash = "f47d9a1c70e204724b1c0fcf2f21cf80b8990c2be0b7b319aeec0429291ea0b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ pyyaml = "^6.0"
 spliceai = "^1.3.1"
 tensorflow = ">=1.2.0"
 psycopg2-binary = "^2.9.9"
+click = "^8.1.7"
+
+[tool.poetry.scripts]
+hgvs2seq = "hgvs2seq.cli:main"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.4.2"

--- a/tests/test_nmd.py
+++ b/tests/test_nmd.py
@@ -1,0 +1,111 @@
+import pytest
+from hgvs2seq.config import TranscriptConfig
+from hgvs2seq.consequence.nmd import check_nmd
+
+# A consistent, well-defined reference sequence for testing.
+# Exons (conceptual cDNA locations): 1-100, 101-200, 201-300.
+# CDS: c.25-c.279. Length is 255 bp (85 codons).
+# The reference CDS has its stop codon at the end.
+REF_CDS = ("ATG" * 84) + "TGA"
+REF_CDNA = "T" * 24 + REF_CDS + "T" * (300 - 24 - len(REF_CDS))
+REF_PROTEIN = "M" * 84 + "*"
+
+@pytest.fixture
+def nmd_transcript_config() -> TranscriptConfig:
+    """
+    Provides a transcript configuration that is consistent with the
+    reference sequences defined in this test module.
+    """
+    return TranscriptConfig(
+        transcript_id="NM_NMD",
+        gene_symbol="NMD_GENE",
+        assembly="GRCh38",
+        strand=1,
+        # 3 exons, each 100bp long for simplicity in calculating junction positions
+        exons=[(1, 100), (201, 300), (401, 500)],
+        cds_start_c=25,
+        cds_end_c=279,  # 25 + 255 - 1 = 279
+    )
+
+def test_nmd_likely_with_default_threshold(nmd_transcript_config: TranscriptConfig):
+    """
+    Tests if a PTC >50bp from the last junction is correctly flagged as 'NMD_likely'.
+    """
+    config = nmd_transcript_config
+    # Last junction is at cDNA position 200.
+    # We will introduce a PTC at c.139 by changing the codon from ATG -> TAG.
+    # The cDNA position of the PTC is 139.
+    # The distance from the last junction is 200 - 139 = 61 nt.
+    # Since 61 >= 50 (default threshold), this should be NMD_likely.
+    edited_cdna_list = list(REF_CDNA)
+    edited_cdna_list[138] = 'T'  # c.139A>T
+    edited_cdna_list[139] = 'A'  # c.140T>A, creating a TAG stop codon
+    edited_cdna = "".join(edited_cdna_list)
+
+    result = check_nmd(edited_cdna, REF_PROTEIN, config)
+
+    assert result["result"] == "NMD_likely"
+    assert result["ptc_position"] == 139
+    assert result["distance"] == 61
+    assert ">= 50 nt" in result["reason"]
+
+def test_nmd_escaped_with_custom_threshold(nmd_transcript_config: TranscriptConfig):
+    """
+    Tests if the same variant can be 'NMD_escaped' by providing a higher custom threshold.
+    """
+    config = nmd_transcript_config
+    # Same setup as before, PTC is 61 nt from the last junction.
+    edited_cdna_list = list(REF_CDNA)
+    edited_cdna_list[138] = 'T'  # c.139A>T
+    edited_cdna_list[139] = 'A'  # c.140T>A, creating a TAG stop codon
+    edited_cdna = "".join(edited_cdna_list)
+
+    # Now, we set a custom threshold of 70. Since 61 < 70, it should escape.
+    result = check_nmd(edited_cdna, REF_PROTEIN, config, nmd_threshold=70)
+
+    assert result["result"] == "NMD_escaped"
+    assert result["distance"] == 61
+    assert "< 70 nt" in result["reason"]
+
+def test_nmd_escaped_ptc_in_last_exon(nmd_transcript_config: TranscriptConfig):
+    """
+    Tests if a PTC in the last exon is correctly flagged as 'NMD_escaped',
+    regardless of the threshold.
+    """
+    config = nmd_transcript_config
+    # Last junction is at position 200.
+    # Let's introduce a PTC at cDNA position 211 (in the last exon) by changing ATG -> TAG.
+    edited_cdna_list = list(REF_CDNA)
+    edited_cdna_list[210] = 'T'  # c.211A>T
+    edited_cdna_list[211] = 'A'  # c.212T>A
+    edited_cdna = "".join(edited_cdna_list)
+
+    # This should escape even with a very small threshold.
+    result = check_nmd(edited_cdna, REF_PROTEIN, config, nmd_threshold=10)
+
+    assert result["result"] == "NMD_escaped"
+    assert result["reason"] == "PTC is located in the last exon."
+
+def test_nmd_escaped_intronless_transcript():
+    """
+    Tests if an intronless transcript is correctly flagged as 'NMD_escaped'.
+    """
+    intronless_config = TranscriptConfig(
+        transcript_id="NM_INTLRNLESS",
+        gene_symbol="INTLRNLESS_GENE",
+        assembly="GRCh38",
+        strand=1,
+        exons=[(1, 300)],  # Only one exon
+        cds_start_c=25,
+        cds_end_c=279,
+    )
+    # This PTC would otherwise be NMD-likely if there were junctions.
+    edited_cdna_list = list(REF_CDNA)
+    edited_cdna_list[138] = 'T'
+    edited_cdna_list[139] = 'A'
+    edited_cdna = "".join(edited_cdna_list)
+
+    result = check_nmd(edited_cdna, REF_PROTEIN, intronless_config)
+
+    assert result["result"] == "NMD_escaped"
+    assert result["reason"] == "Intronless transcript."


### PR DESCRIPTION
This change introduces a command-line interface and makes key v0.2 features configurable.

Key changes include:

- Command-Line Interface: A new CLI built with `click` has been added (`hgvs2seq/cli.py`), allowing users to run predictions from the terminal.
- Configurable NMD Threshold: The NMD prediction logic now accepts a custom threshold (`--nmd-threshold`), making the "50-nucleotide rule" tunable.
- Configurable SpliceAI Distance: The SpliceAI distance parameter is now exposed through the CLI (`--spliceai-distance`), allowing for more flexible splice-site analysis.
- New Tests: Added a dedicated test suite for the NMD logic (`tests/test_nmd.py`) to verify the correctness of the new configurable threshold.
- Dependency Management: Resolved an installation issue by removing the direct `psycopg2` dependency from `hgvs` in the lock file, ensuring `psycopg2-binary` is used instead.